### PR TITLE
Use a dummy server localhost instead of 192.0.2.1 for test

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,6 +11,7 @@ my $builder = Module::Build->new( module_name        => 'DBD::Multi',
                                   release_status     => 'stable',
                                   configure_requires => { 'Module::Build' => '0', },
                                   build_requires     => {
+                                                      'Test::TCP'           => '0',
                                                       'Test::More'          => '0',
                                                       'Test::Pod::Coverage' => '1.04',
                                                       'Test::Pod'           => '1.14',


### PR DESCRIPTION
The t/unavailable-server.t's subtest Direct connection timed out' uses
192.0.2.1 host in a hope the the TCP connection will time out. But this is
not true in properly configured network because 192.0.2.0/24
destination should be blocked by routers and properly blocked means to
return an ICMP error message and that means an operating system will
return an error to the process very quickly within the timeout
interval. Then the test fails like this:

DBI connect('dbname=fake;host=192.0.2.1','fakeuser',...) failed: could not connect to server: No route to host
	Is the server running on host "192.0.2.1" and accepting
	TCP/IP connections on port 5432? at t/unavailable-server.t line 43.

This creates a dummy TCP server with Test::TCP module on 127.0.0.1
that will never reply to clients with a valid PostgreSQL message. This
allows to perform the test correctly in all network setups, even
without the Internet.

<https://github.com/dwright/DBD-Multi/issues/2>